### PR TITLE
feat(int-7055): adopt CoreDataDome 0.6.1 body-provider DataDomeResponse init

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,25 +1,24 @@
 {
-  "object": {
-    "pins": [
-      {
-        "package": "Alamofire",
-        "repositoryURL": "https://github.com/Alamofire/Alamofire.git",
-        "state": {
-          "branch": null,
-          "revision": "513364f870f6bfc468f9d2ff0a95caccc10044c5",
-          "version": "5.10.2"
-        }
-      },
-      {
-        "package": "CoreDataDome",
-        "repositoryURL": "git@github.com:DataDome/mobile-package-ios-coredatadome.git",
-        "state": {
-          "branch": null,
-          "revision": "6e6233cf193d00f392668a72066caf979bbaf6a1",
-          "version": "0.6.0"
-        }
+  "originHash" : "2bf8c3fa6a31614e159b410dca82828ae37809009a668d716a283098773bffe9",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "513364f870f6bfc468f9d2ff0a95caccc10044c5",
+        "version" : "5.10.2"
       }
-    ]
-  },
-  "version": 1
+    },
+    {
+      "identity" : "mobile-package-ios-coredatadome",
+      "kind" : "remoteSourceControl",
+      "location" : "git@github.com:DataDome/mobile-package-ios-coredatadome.git",
+      "state" : {
+        "branch" : "0.6.1",
+        "revision" : "416f0d020036f080d1c7f36d5c7f16c1ff2a1e30"
+      }
+    }
+  ],
+  "version" : 3
 }

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0"),
-        .package(url: "git@github.com:DataDome/mobile-package-ios-coredatadome.git", exact: "0.6.0")
+        .package(url: "git@github.com:DataDome/mobile-package-ios-coredatadome.git", branch: "0.6.1")
     ],
     targets: [
         .target(

--- a/SampleApp/SampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApp/SampleApp.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "git@github.com:DataDome/mobile-package-ios-coredatadome.git",
       "state" : {
-        "revision" : "6e6233cf193d00f392668a72066caf979bbaf6a1",
-        "version" : "0.6.0"
+        "branch" : "0.6.1",
+        "revision" : "416f0d020036f080d1c7f36d5c7f16c1ff2a1e30"
       }
     }
   ],

--- a/Sources/DataDomeAlamofire/DataDomeInterceptor.swift
+++ b/Sources/DataDomeAlamofire/DataDomeInterceptor.swift
@@ -65,15 +65,16 @@ public final class DataDomeInterceptor: RequestInterceptor, Sendable {
             return
         }
 
-        let body = (request as? DataRequest)?.data
+        let dataRequest = request as? DataRequest
         let headers = httpResponse.allHeaderFields.reduce(into: [String: String]()) { result, pair in
             if let key = pair.key as? String, let value = pair.value as? String {
                 result[key] = value
             }
         }
+        
         let ddResponse = DataDomeResponse(statusCode: httpResponse.statusCode,
                                           headers: headers,
-                                          body: body)
+                                          bodyProvider: { dataRequest?.data })
 
         let dataDome = self.dataDome
         Task {


### PR DESCRIPTION
## Context

[INT-7046](https://datadome.atlassian.net/browse/INT-7046) added a new `DataDomeResponse` initialiser to CoreDataDome that takes a *lazy* body provider (`@escaping @Sendable () -> Data?`, Obj-C selector `initWithStatusCode:headers:bodyProvider:`) instead of a materialised `Data?`. The body is only read on the challenge path, so consumers can defer producing it. It ships in CoreDataDome `0.6.1`.

This PR adapts the Alamofire integration to depend on `0.6.1` and adopt the new initialiser.

## Changes

- **`Package.swift`** — bump the CoreDataDome dependency to the `0.6.1` branch.
- **`DataDomeInterceptor`** — build `DataDomeResponse` via the new `bodyProvider:` initialiser, passing a closure that lazily returns the Alamofire `DataRequest` response data, so the body is only read when the SDK needs it (challenge path). The closure captures `DataRequest` (`@unchecked Sendable`, protected storage), which is safe under Swift 6 strict concurrency.
- **`Package.resolved`** (package + SampleApp) — re-resolved to CoreDataDome `0.6.1` (`416f0d0`).

## Verification

- `xcodebuild … DataDomeAlamofire -destination 'generic/platform=iOS Simulator'` → **BUILD SUCCEEDED** (arm64 + x86_64, `-swift-version 6`, no concurrency errors).
- `xcodebuild … SampleApp …` → **BUILD SUCCEEDED**, confirming end-to-end linking against `0.6.1`.

## Notes

- Stacked on `feat/int-6975_migrate-to-CoreDataDome`; retarget to `master` once that branch merges.
- `branch: "0.6.1"` is a temporary pin tracking the in-flight build — switch to `exact: "0.6.1"` once `0.6.1` is tagged/released (matches the existing pin-to-exact convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[INT-7046]: https://datadome.atlassian.net/browse/INT-7046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INT-7055]: https://datadome.atlassian.net/browse/INT-7055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ